### PR TITLE
Fix segfault due to failing mmap

### DIFF
--- a/pwmctl.c
+++ b/pwmctl.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <linux/pci.h>
 
-static __off_t get_fpga_phy(void);
+static off_t get_fpga_phy(void);
 
 
 static void usage(void)
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
    int c, devmem, chan, duty, gen;
    unsigned int reg;
    volatile unsigned int *syscon;
-   __off_t syscon_phy;
+   off_t syscon_phy;
 
    chan=duty=-1;
    gen=0;
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
 
    if ((syscon_phy = get_fpga_phy()) == 0) {
       fprintf(stderr, "Warning:  Did not discover FPGA base from PCI probe\n");
-      syscon_phy = (__off_t)0xFC081000;
+      syscon_phy = (off_t)0xFC081000;
    }
 
    devmem = open("/dev/mem", O_RDWR|O_SYNC);
@@ -125,9 +125,9 @@ int main(int argc, char *argv[])
 /**
    Try to extract the base of the FPGA by looking at the specific bus/slot
 */
-static __off_t get_fpga_phy(void)
+static off_t get_fpga_phy(void)
 {
-   static __off_t fpga = 0;
+   static off_t fpga = 0;
 
    if (fpga == 0) {
       unsigned int config[PCI_STD_HEADER_SIZEOF];

--- a/ts7800ctl.c
+++ b/ts7800ctl.c
@@ -103,8 +103,8 @@ enum pcbrev {
 #define SILABS_CHIP_ADDRESS 0x54
 #define ACCELEROMETER_CHIP_ADDRESS 0x1c
 
-static __off_t syscon_phy;
-static __off_t get_fpga_phy(void);
+static off_t syscon_phy;
+static off_t get_fpga_phy(void);
 
 
 static volatile unsigned int *syscon, *cpuregs;
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
 
 	if ((syscon_phy = get_fpga_phy()) == 0) {
 		fprintf(stderr, "Warning:  Did not discover FPGA base from PCI probe\n");
-		syscon_phy = (__off_t)0xFC081000;
+		syscon_phy = (off_t)0xFC081000;
 	}
 
 
@@ -1108,9 +1108,9 @@ static inline void do_silabs_sleep(unsigned int deciseconds)
 /**
 	Try to extract the base of the FPGA by looking at the specific bus/slot
 */
-static __off_t get_fpga_phy(void)
+static off_t get_fpga_phy(void)
 {
-	static __off_t fpga = 0;
+	static off_t fpga = 0;
 
 	if (fpga == 0) {
 		unsigned int config[PCI_STD_HEADER_SIZEOF];


### PR DESCRIPTION
This replaces all occurences of __off_t by off_t.

This is to prevent mmap failing in systems where off_t is 64-bit and
__off_t is 32-bit. The failure was due to the passing of a negative
__off_t, which was implicitly sign extended to 64-bit before being
passed to mmap.